### PR TITLE
BLK-193 Removes redundant scheduler initialization from tests

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -32,7 +32,6 @@ class TestSimulator(NIOBlockTestCase):
         notified two sets of signals.
         """
         print("Testing:", self.Simulator.__name__)
-        SchedulerModule.module_init({})
         sim = self.Simulator()
 
         self.configure_block(sim, config)

--- a/tests/test_simulator_fast.py
+++ b/tests/test_simulator_fast.py
@@ -29,7 +29,6 @@ class TestSimulator(NIOBlockTestCase):
         notified two sets of signals.
         """
         print("Testing:", self.Simulator.__name__)
-        SchedulerModule.module_init({})
         sim = self.Simulator()
 
         self.configure_block(sim, config)


### PR DESCRIPTION
Signed-off-by: Oren Leiman mumblemumble777@gmail.com
