### PR TITLE
Fixed Interval Trigger so extra signals won't be notified

### DIFF
--- a/tests/triggers/test_interval.py
+++ b/tests/triggers/test_interval.py
@@ -3,11 +3,11 @@ from time import sleep
 from ...triggers.interval import IntervalTrigger
 from nio import Signal, Block
 from nio.testing.block_test_case import NIOBlockTestCase
+from ...multiple import MultipleSignals
 
 
 class SampleIntervalBlock(IntervalTrigger, Block):
     pass
-
 
 class TestInterval(NIOBlockTestCase):
 
@@ -48,25 +48,38 @@ class TestInterval(NIOBlockTestCase):
 
         self.assert_num_signals_notified(1)
 
-    def test_total_signals_2(self):
-        ''' This time we are testing total_signals where it is not a multiple
-        of generate_signals'''
+    def test_extra_generated_signals(self):
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
-                'seconds': 1
+                'seconds': 0.1
             },
-            'total_signals': 1
+            'total_signals': 5
         })
+
         returns = [Signal(), Signal()]
         interval.generate_signals = MagicMock(return_value=returns)
-
         interval.start()
-        # Give it enough time for two notifications
-        # but then the second one should not notify
-        sleep(1.5)
+        sleep(0.5)
         interval.stop()
 
-        # Even though total_signals is 1, this is 2 because generate is
-        # creating two signals per notification.
-        self.assert_num_signals_notified(2)
+        self.assert_num_signals_notified(5)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/triggers/test_interval.py
+++ b/tests/triggers/test_interval.py
@@ -67,4 +67,6 @@ class TestInterval(NIOBlockTestCase):
         sleep(0.5)
         interval.stop()
 
+        # Although 6 signals are notified, the interval trigger only allows
+        # 5 signals to be notified because total_signals is 5
         self.assert_num_signals_notified(5)

--- a/tests/triggers/test_interval.py
+++ b/tests/triggers/test_interval.py
@@ -10,8 +10,7 @@ class SampleIntervalBlock(IntervalTrigger, Block):
 class TestInterval(NIOBlockTestCase):
 
     def test_interval_default(self):
-        '''Testing to see if interval trigger notifies all signals
-            when total signals is not specified. '''
+        ''' Testing if interval trigger notifies all signals when total signals is not specified. '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
@@ -30,8 +29,7 @@ class TestInterval(NIOBlockTestCase):
         self.assert_num_signals_notified(4)
 
     def test_total_signals(self):
-        '''Testing if total_signals limits notified signals to 
-            one despite enough time for two signals generated '''
+        ''' Testing if total_signals limits notified signals to one despite enough time for two signals generated '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
@@ -51,8 +49,7 @@ class TestInterval(NIOBlockTestCase):
         self.assert_num_signals_notified(1)
 
     def test_extra_generated_signals(self):
-        '''Testing to see if 5 signals are notified despite 6 signals
-            being generated due to multiple signals '''
+        '''Testing to see if 5 signals are notified despite 6 signals being generated due to multiple signals '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {

--- a/tests/triggers/test_interval.py
+++ b/tests/triggers/test_interval.py
@@ -3,8 +3,6 @@ from time import sleep
 from ...triggers.interval import IntervalTrigger
 from nio import Signal, Block
 from nio.testing.block_test_case import NIOBlockTestCase
-from ...multiple import MultipleSignals
-
 
 class SampleIntervalBlock(IntervalTrigger, Block):
     pass
@@ -12,6 +10,8 @@ class SampleIntervalBlock(IntervalTrigger, Block):
 class TestInterval(NIOBlockTestCase):
 
     def test_interval_default(self):
+        '''Testing to see if interval trigger notifies all signals
+            when total signals is not specified. '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
@@ -30,6 +30,8 @@ class TestInterval(NIOBlockTestCase):
         self.assert_num_signals_notified(4)
 
     def test_total_signals(self):
+        '''Testing if total_signals limits notified signals to 
+            one despite enough time for two signals generated '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
@@ -49,6 +51,8 @@ class TestInterval(NIOBlockTestCase):
         self.assert_num_signals_notified(1)
 
     def test_extra_generated_signals(self):
+        '''Testing to see if 5 signals are notified despite 6 signals
+            being generated due to multiple signals '''
         interval = SampleIntervalBlock()
         self.configure_block(interval, {
             'interval': {
@@ -64,22 +68,3 @@ class TestInterval(NIOBlockTestCase):
         interval.stop()
 
         self.assert_num_signals_notified(5)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/triggers/interval.py
+++ b/triggers/interval.py
@@ -38,9 +38,6 @@ class IntervalTrigger():
             # signals mixin was used) to the counter and notify them
             self.counter += len(sigs)
             
-            #check to see if counter > total_signals
-            #if true, then pop list (counter - total_signals)
-            #amount of times
             if self.counter > self.total_signals() and self.total_signals() >= 0:
                 #self.counter - self.total_signals() yield that amount of signals that should be removed
                 sigs_to_remove = self.counter - self.total_signals()

--- a/triggers/interval.py
+++ b/triggers/interval.py
@@ -37,6 +37,16 @@ class IntervalTrigger():
             # Add however many signals were generated (in case multiple
             # signals mixin was used) to the counter and notify them
             self.counter += len(sigs)
+            
+            #check to see if counter > total_signals
+            #if true, then pop list (counter - total_signals)
+            #amount of times
+            if self.counter > self.total_signals() and self.total_signals() >= 0:
+                # for i in range(self.counter - self.total_signals()):
+                #     sigs.pop()
+                sigs_to_remove = self.counter - self.total_signals()
+                sigs = sigs[:-1 * sigs_to_remove]
+
             self.notify_signals(sigs)
 
             if self.total_signals() > 0 and \

--- a/triggers/interval.py
+++ b/triggers/interval.py
@@ -42,8 +42,7 @@ class IntervalTrigger():
             #if true, then pop list (counter - total_signals)
             #amount of times
             if self.counter > self.total_signals() and self.total_signals() >= 0:
-                # for i in range(self.counter - self.total_signals()):
-                #     sigs.pop()
+                #self.counter - self.total_signals() yield that amount of signals that should be removed
                 sigs_to_remove = self.counter - self.total_signals()
                 sigs = sigs[:-1 * sigs_to_remove]
 


### PR DESCRIPTION
When the number of signals generated is greater than the total_signals value, the extra signals are now removed from the list of signals in the Interval Trigger.